### PR TITLE
Add PHPStan Level 5 static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
 		],
 		"fix": [
 			"phpcbf --standard=phpcs.ruleset.xml $(find ./ -name '*.php')"
-		]
+		],
+		"phpstan": "phpstan analyse --memory-limit=1G"
 	},
 	"authors": [
 		{
@@ -23,7 +24,10 @@
 	"require-dev": {
 		"squizlabs/php_codesniffer": "^3.0",
 		"wp-coding-standards/wpcs": "^3.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+		"phpstan/phpstan": "^2.1",
+		"szepeviktor/phpstan-wordpress": "^2.0",
+		"php-stubs/wordpress-stubs": "^6.9"
 	},
 	"config": {
 		"allow-plugins": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,25 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Default value of the parameter \#2 \$target \(string\) of function taro_taxonomy_parse_args\(\) is incompatible with type bool\.$#'
+			identifier: parameter.defaultValue
+			count: 1
+			path: taro-taxonomy-blocks.php
+
+		-
+			message: '#^Parameter \#1 \$target of function taro_taxonomy_terms_blocks_option expects string, bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: taro-taxonomy-blocks.php
+
+		-
+			message: '#^Parameter \#2 \$output of function get_taxonomies expects ''names''\|''objects'', ''OBJECT'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: taro-taxonomy-blocks.php
+
+		-
+			message: '#^Parameter \#2 \$target of function taro_taxonomy_parse_args expects bool, string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: taro-taxonomy-blocks.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - taro-taxonomy-blocks.php
+        - includes/


### PR DESCRIPTION
## Summary
- PHPStan Level 5 + WordPress extensions を追加
- 既存エラーは baseline に記録（新規コードのみ Level 5 準拠を要求）
- `composer phpstan` で実行可能

タロスカイ全プラグイン標準化の一環。

🤖 Generated with [Claude Code](https://claude.com/claude-code)